### PR TITLE
Change 'extras' column from TEXT to LONGTEXT

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "illuminate/support": "~5.1",
         "php" : "~5.5|~7.0",
         "cviebrock/eloquent-sluggable": "^4.0",
-        "backpack/crud": "^3.0.6"
+        "backpack/crud": "^3.0.6",
+        "doctrine/dbal": "^2.5.12"
     },
     "require-dev": {
         "phpunit/phpunit" : "4.*",

--- a/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
+++ b/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class ChangeExtrasToLongtext extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pages', function( Blueprint $table) {
+            $table->longText('extras')->change();
+        })
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pages', function( Blueprint $table) {
+            $table->text('extras')->change();
+        })
+    }
+}

--- a/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
+++ b/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
@@ -15,7 +15,7 @@ class ChangeExtrasToLongtext extends Migration
     {
         Schema::table('pages', function( Blueprint $table) {
             $table->longText('extras')->change();
-        })
+        });
     }
 
     /**

--- a/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
+++ b/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
@@ -27,6 +27,6 @@ class ChangeExtrasToLongtext extends Migration
     {
         Schema::table('pages', function( Blueprint $table) {
             $table->text('extras')->change();
-        })
+        });
     }
 }


### PR DESCRIPTION
Due to any “image” field type being stored by default as Base64, when trying to add anything else such as a link, video, etc it becomes too long for the field. To make this change requires `Doctrine/dbal`.