### PR TITLE
Update PageCrudController.php

### DIFF
--- a/src/app/Http/Controllers/Admin/PageCrudController.php
+++ b/src/app/Http/Controllers/Admin/PageCrudController.php
@@ -180,7 +180,7 @@ class PageCrudController extends CrudController
         $templates_array = [];
 
         $templates_trait = new \ReflectionClass('App\PageTemplates');
-        $templates = $templates_trait->getMethods();
+        $templates = $templates_trait->getMethods(\ReflectionMethod::IS_PRIVATE);
 
         if (! count($templates)) {
             abort('403', 'No templates have been found.');


### PR DESCRIPTION
Add method filter to enable field sharing between templates using protected functions.

Context: I wanted to add the same meta fields to all registered templates and follow DRY but the getTemplates method uses getMethods with no filter.