### PR TITLE
Fix for Bug 38 (Non-Existent Template Configuration Causes PHP Language Level Exception)

### DIFF
--- a/src/app/Http/Controllers/Admin/PageCrudController.php
+++ b/src/app/Http/Controllers/Admin/PageCrudController.php
@@ -183,7 +183,9 @@ class PageCrudController extends CrudController
         $templates = $templates_trait->getMethods();
 
         if (! count($templates)) {
-            abort('403', 'No templates have been found.');
+                abort(503, "The template '$template_name' cannot be found in " .
+                    "the page manager's configuration. To continue, you must "
+                    ."request for this to be fixed.");
         }
 
         return $templates;

--- a/src/app/Http/Controllers/Admin/PageCrudController.php
+++ b/src/app/Http/Controllers/Admin/PageCrudController.php
@@ -183,9 +183,9 @@ class PageCrudController extends CrudController
         $templates = $templates_trait->getMethods();
 
         if (! count($templates)) {
-                abort(503, "The template '$template_name' cannot be found in " .
+            abort(503, "The template '$template_name' cannot be found in ".
                     "the page manager's configuration. To continue, you must "
-                    ."request for this to be fixed.");
+                    .'request for this to be fixed.');
         }
 
         return $templates;


### PR DESCRIPTION
- Intercept the code and if the method does not exist, throw a nicer error

(See #38).