### PR TITLE
Added french translation

### DIFF
--- a/src/resources/lang/fr/pagemanager.php
+++ b/src/resources/lang/fr/pagemanager.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+    'change_template_confirmation'  => 'Confirmez-vous le changement de modèle? Toutes les modifications non enregistrées pour cette page seront perdues.',
+    'content'                       => 'Contenu',
+    'content_placeholder'           => 'Saisissez le contenu de la page ici',
+    'meta_description'              => 'Méta description',
+    'meta_keywords'                 => 'Méta mots-clés',
+    'meta_title'                    => 'Méta titre',
+    'metas'                         => 'Balises META',
+    'name'                          => 'Nom',
+    'open'                          => 'Ouvrir',
+    'page'                          => 'page',
+    'page_name'                     => 'Nom de page (visible uniquement par les admins)',
+    'page_slug'                     => 'Url simplifiée',
+    'page_slug_hint'                => 'Sera générée automatiquement à partir du titre si laissée vide.',
+    'page_title'                    => 'Titre de la page',
+    'pages'                         => 'pages',
+    'slug'                          => 'Url simplifiée',
+    'template'                      => 'Modèle',
+    'template_not_found'            => 'Le modèle de page n’a pu être trouvé. Il a dû être supprimé ou renommé depuis la création de cette page. Pour poursuivre, veuillez demander l’intervention de votre webmaster ou développeur.',
+];


### PR DESCRIPTION
Some words don't have academic equivalent in french, like "meta keywords" and "slugs".
I opted for the most understandable version but we could append the english word after it, even if that seems a bit overkill. 
ie: for the page slug : "Url simplifiée (“Slug”)"

Also, this file strangely doesn't adopt the formating style of the other Laravel Backpack packages language files (no commenting header, no tabbing alignment). I don't know if its a omission or not, so feel free to alter the tabbing or add a comment header!