### PR TITLE
Fix to allow for custom auth guards

### DIFF
--- a/src/app/Http/Requests/PageRequest.php
+++ b/src/app/Http/Requests/PageRequest.php
@@ -14,7 +14,7 @@ class PageRequest extends \Backpack\CRUD\app\Http\Requests\CrudRequest
     public function authorize()
     {
         // only allow updates if the user is logged in
-        return \Auth::check();
+        return backpack_auth()->check();
     }
 
     /**


### PR DESCRIPTION
This fix allows for custom auth guards. This uses the backpack custom guard helper.