### PR TITLE
Added setting to use external code coverage

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -10,6 +10,7 @@ filter:
         - 'vendor/*'
         - 'views/*'
 tools:
+    external_code_coverage: true
     php_analyzer: true
     php_mess_detector: true
     php_changetracking: true


### PR DESCRIPTION
Code coverage is generated from Travis CI and this setting is necessary in order to display it