### PR TITLE
bugfix page template select element on change, revert to previous value when user click cancel on confirmation box

### DIFF
--- a/src/resources/views/vendor/backpack/crud/fields/select_page_template.blade.php
+++ b/src/resources/views/vendor/backpack/crud/fields/select_page_template.blade.php
@@ -66,12 +66,15 @@
             }
 
             jQuery(document).ready(function($) {
+                $('#select_template').data('current', $('#select_template').val());
+
                 $("#select_template").change(function(e) {
                     var select_template_confirmation = confirm("@lang('backpack::pagemanager.change_template_confirmation')");
                     if (select_template_confirmation == true) {
                         redirect_to_new_page_with_template_parameter();
                     } else {
                         // txt = "You pressed Cancel!";
+                        $('#select_template').val($('#select_template').data('current'));
                     }
                 });
 


### PR DESCRIPTION
When user change the page template then click cancel on the confirmation box, the select / dropdown value still changed. This PR try to address that issue.

Here's a video when I tried it on backpack demo website.

![2020-09-23-15-22-24](https://user-images.githubusercontent.com/13914485/93980127-ccc8bb00-fdb0-11ea-8c39-bba757121eff.gif)
