### PR TITLE
bugfix PageManagerServiceProvider.php 

### DIFF
--- a/src/PageManagerServiceProvider.php
+++ b/src/PageManagerServiceProvider.php
@@ -41,8 +41,6 @@ class PageManagerServiceProvider extends ServiceProvider
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
 
         $this->mergeConfigFrom(__DIR__.'/config/pagemanager.php', 'backpack.pagemanager');
-
-        // then load the stock views
         $this->loadViewsFrom(realpath(__DIR__.'/resources/views/vendor/backpack/crud'), 'pagemanager');
     }
 

--- a/src/PageManagerServiceProvider.php
+++ b/src/PageManagerServiceProvider.php
@@ -42,12 +42,6 @@ class PageManagerServiceProvider extends ServiceProvider
 
         $this->mergeConfigFrom(__DIR__.'/config/pagemanager.php', 'backpack.pagemanager');
 
-        // first load published/overwritten views
-        $customViewsFolder = resource_path('views/vendor/backpack/crud');
-        if (file_exists($customViewsFolder)) {
-            $this->loadViewsFrom($customViewsFolder, 'pagemanager');
-        }
-
         // then load the stock views
         $this->loadViewsFrom(realpath(__DIR__.'/resources/views/vendor/backpack/crud'), 'pagemanager');
     }

--- a/src/PageManagerServiceProvider.php
+++ b/src/PageManagerServiceProvider.php
@@ -41,7 +41,9 @@ class PageManagerServiceProvider extends ServiceProvider
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
 
         $this->mergeConfigFrom(__DIR__.'/config/pagemanager.php', 'backpack.pagemanager');
+
         $this->loadViewsFrom(base_path('resources/views/vendor/backpack/crud'), 'pagemanager');
+        $this->loadViewsFrom(realpath(__DIR__.'/resources/views/vendor/backpack/crud'), 'pagemanager');
     }
 
     /**

--- a/src/PageManagerServiceProvider.php
+++ b/src/PageManagerServiceProvider.php
@@ -42,7 +42,13 @@ class PageManagerServiceProvider extends ServiceProvider
 
         $this->mergeConfigFrom(__DIR__.'/config/pagemanager.php', 'backpack.pagemanager');
 
-        $this->loadViewsFrom(base_path('resources/views/vendor/backpack/crud'), 'pagemanager');
+        // first load published/overwritten views
+        $customViewsFolder = resource_path('views/vendor/backpack/crud');
+        if (file_exists($customViewsFolder)) {
+            $this->loadViewsFrom($customViewsFolder, 'pagemanager');
+        }
+
+        // then load the stock views
         $this->loadViewsFrom(realpath(__DIR__.'/resources/views/vendor/backpack/crud'), 'pagemanager');
     }
 

--- a/src/PageManagerServiceProvider.php
+++ b/src/PageManagerServiceProvider.php
@@ -41,7 +41,7 @@ class PageManagerServiceProvider extends ServiceProvider
         $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
 
         $this->mergeConfigFrom(__DIR__.'/config/pagemanager.php', 'backpack.pagemanager');
-        $this->loadViewsFrom(realpath(__DIR__.'/resources/views/vendor/backpack/crud'), 'pagemanager');
+        $this->loadViewsFrom(base_path('resources/views/vendor/backpack/crud'), 'pagemanager');
     }
 
     /**

--- a/src/app/Http/Controllers/Admin/PageCrudController.php
+++ b/src/app/Http/Controllers/Admin/PageCrudController.php
@@ -85,7 +85,7 @@ class PageCrudController extends CrudController
             'name' => 'template',
             'label' => trans('backpack::pagemanager.template'),
             'type' => 'select_page_template',
-            'view_namespace'  => 'pagemanager::fields',
+            'view_namespace' => file_exists(resource_path('views/vendor/backpack/crud/fields/select_page_template.blade.php')) ? null : 'pagemanager::fields',
             'options' => $this->getTemplatesArray(),
             'value' => $template,
             'allows_null' => false,


### PR DESCRIPTION
Bugfix service provider does not load published field view after installation

Steps to reproduce bug:

1. Install PageManager until finished, including following the `php artisan vendor:publish --provider="Backpack\PageManager\PageManagerServiceProvider"` step
2. Try to change something in the published view (`resources/views/vendor/backpack/crud/fields/select_page_template.blade.php`), for example just add an `alert('test')`
3. Alert not shows up