### PR TITLE
Update README.md to include setExtrasAttribute()

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ If you need to make any modifications to the controller, model or request, you s
 - create a new controller/model that extends the one in the package;
 - enter controller or model in the pagemanager.php config file, and that's the one that the CRUD will be using;
 
+## Optional: Mutator for fields using 'store_in' and 'fake' keys
+
+Fake fields do not trigger individual mutators, they trigger the "fake column" mutator. For example instead of defining a `setImageAttribute()` mutator, please define a `setExtrasAttribute()` mutator. You'll have the `$value` then.
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
Added in details of how to extend the 'extras' etc fake fields with mutators after receiving support here: https://stackoverflow.com/questions/76276923/issue-uploading-files-with-pagemanager/76280472#76280472

## WHY

I was unable to find this information on the Backpack documentation. I suspect partly because this is localised to PageManager.

### BEFORE - What was wrong? What was happening before this PR?

N/A

### AFTER - What is happening after this PR?

I've updated with the documentation provided in the Stack Overflow question. https://stackoverflow.com/questions/76276923/issue-uploading-files-with-pagemanager/76280472#76280472


## HOW

### How did you achieve that, in technical terms?

Updating of readme file.

### Is it a breaking change or non-breaking change?

Documentation only, non-breaking

### How can we test the before & after?

N/A
