### PR TITLE
Fix error when trying to create a page without extras

### DIFF
--- a/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
+++ b/src/database/migrations/2017_04_10_195926_change_extras_to_longtext.php
@@ -14,7 +14,7 @@ class ChangeExtrasToLongtext extends Migration
     public function up()
     {
         Schema::table('pages', function (Blueprint $table) {
-            $table->longText('extras')->change();
+            $table->longText('extras')->nullable()->change();
         });
     }
 
@@ -26,7 +26,7 @@ class ChangeExtrasToLongtext extends Migration
     public function down()
     {
         Schema::table('pages', function (Blueprint $table) {
-            $table->text('extras')->change();
+            $table->text('extras')->nullable()->change();
         });
     }
 }


### PR DESCRIPTION
## WHY

### BEFORE - What was wrong? What was happening before this PR?

I installed PageManager and tried to create a simple "terms and conditions" page using this template:

```php
    private function document(): void
    {
        $this->crud->addField([
            'name' => 'content',
            'label' => trans('backpack::pagemanager.content'),
            'type' => 'summernote',
            'placeholder' => trans('backpack::pagemanager.content_placeholder'),
        ]);
    }
```

But I couldn't do that. As soon as I hit "save" in the create form, I was hit with a big fat DB error saying that the `extras` column doesn't have a default.

### AFTER - What is happening after this PR?

It looks like we have two migrations for this package. The first one creates the table, the second one changes the length of the `extras` column. But when it does that... it no longer has `nullable` on it, so that's forgotten.

So I've just added `nullable` to it - and now it works.

## HOW

### How did you achieve that, in technical terms?

Added `nullable` in the second migration file.



### Is it a breaking change or non-breaking change?

Non-breaking imho but @pxpm please think about it too.


### How can we test the before & after?

Try to do the same thing I explained above, in a new project. You should get an error too.
